### PR TITLE
UAgent-DrClaw: Autonomous ML Pipeline Optimization Prototype

### DIFF
--- a/README_drclaw.md
+++ b/README_drclaw.md
@@ -1,0 +1,43 @@
+# UAgent-DrClaw: Autonomous ML Pipeline Optimization Prototype
+
+UAgent-DrClaw is a standalone, headless autonomous research loop for optimizing ML input pipeline parameters.
+
+## What it does
+
+- Reads experiment configuration from YAML.
+- Plans parameter updates using a heuristic policy.
+- Executes a pipeline simulation.
+- Evaluates metrics and tracks best configuration.
+- Iterates automatically with failure recovery.
+- Writes reproducible run artifacts.
+
+## Quick start
+
+```bash
+python -m uagent_drclaw.experiment_runner
+```
+
+Optional args:
+
+```bash
+python -m uagent_drclaw.experiment_runner \
+  --config uagent_drclaw/experiments/config.yaml \
+  --output-root uagent_drclaw/results
+```
+
+## Output artifacts
+Each run generates a timestamped folder in `uagent_drclaw/results/` containing:
+- `metrics.json` — per-iteration configs, metrics, score, and decisions.
+- `logs.txt` — textual plan/execute/evaluate trace.
+- `summary.md` — concise best-result summary.
+
+## Architecture
+See:
+- `docs/drclaw_migration.md`
+- `docs/drclaw_architecture.md`
+- `docs/experiment_design.md`
+
+## Extending DrClaw
+- Replace planner with LLM/RL strategy while keeping planner interface.
+- Replace simulator with real training input-pipeline benchmark.
+- Add persistent memory backend (SQLite or vector store).

--- a/docs/drclaw_architecture.md
+++ b/docs/drclaw_architecture.md
@@ -1,0 +1,64 @@
+# UAgent-DrClaw Architecture
+
+## Module layout
+
+```text
+uagent_drclaw/
+  planner/      # Proposes next configuration changes (policy layer)
+  executor/     # Applies config and executes pipeline simulation
+  evaluator/    # Converts metrics to comparable objective scores
+  memory/       # Stores history, best config, and bad-config blacklist
+  experiments/  # Config files and experiment definitions
+  results/      # Per-run outputs
+  experiment_runner.py  # End-to-end autonomous loop entrypoint
+```
+
+## Interfaces
+
+### `planner`
+- Input: current config, previous metrics, memory snapshot.
+- Output: `PlanDecision(candidate_config, reason, reverted)`.
+- Responsibility: propose next experiment with reversible, explainable changes.
+
+### `executor`
+- Input: candidate `PipelineConfig`.
+- Output: `ExperimentMetrics` (or failed metrics with reason).
+- Responsibility: run pipeline and surface bottlenecks + KPI measurements.
+
+### `evaluator`
+- Input: `ExperimentMetrics`.
+- Output: scalar score for improvement checks.
+- Responsibility: objective shaping (throughput + utilization - latency penalty).
+
+### `memory`
+- Input: `(config, metrics, score)` from each iteration.
+- Output: current best config/score and bad-config lookup.
+- Responsibility: persist optimization trajectory and prevent repeated poor attempts.
+
+### `experiments`
+- Contains declarative config (`config.yaml`) for search bounds, initial config, and loop controls.
+
+## Control flow
+
+1. Load experiment config.
+2. Initialize planner/executor/evaluator/memory.
+3. Iterate until convergence criterion:
+   - Plan next config.
+   - Execute experiment.
+   - Evaluate metrics into score.
+   - Update memory.
+   - Revert or continue based on score/failure history.
+4. Write reproducible artifacts (`metrics.json`, `logs.txt`, `summary.md`).
+
+## Failure recovery strategy
+
+- Executor catches runtime errors and emits failed metrics.
+- Planner reacts to failed runs by reverting to `best_config`.
+- Memory marks failed configs as bad to avoid repeating.
+
+## Extension points
+
+- Replace `HeuristicPlanner` with LLM planner or RL agent.
+- Swap `PipelineSimulator` with real benchmark harness.
+- Extend evaluator with multi-objective Pareto scoring.
+- Persist memory into SQLite for long-horizon optimization.

--- a/docs/drclaw_example_artifacts/logs.txt
+++ b/docs/drclaw_example_artifacts/logs.txt
@@ -1,0 +1,18 @@
+[assumption] Pipeline metrics are simulator-derived approximations for research prototyping
+[assumption] Convergence is no-improvement patience based, not statistical significance
+[iter=1] PLAN config={'batch_size': 64, 'num_workers': 2, 'prefetch_size': 2, 'cache_usage': False, 'parallelism': 1} reason=Bootstrap: increase batch_size to probe throughput ceiling
+[iter=1] EVAL score=2511.536 improved=True throughput=2509.446 gpu=28.63 latency=25.336 failed=False
+[iter=2] PLAN config={'batch_size': 64, 'num_workers': 3, 'prefetch_size': 2, 'cache_usage': False, 'parallelism': 1} reason=CPU bottleneck detected; increasing num_workers
+[iter=2] EVAL score=2613.101 improved=True throughput=2610.33 gpu=30.26 latency=23.971 failed=False
+[iter=3] PLAN config={'batch_size': 64, 'num_workers': 4, 'prefetch_size': 2, 'cache_usage': False, 'parallelism': 1} reason=CPU bottleneck detected; increasing num_workers
+[iter=3] EVAL score=2699.013 improved=True throughput=2695.886 gpu=31.14 latency=23.289 failed=False
+[iter=4] PLAN config={'batch_size': 64, 'num_workers': 5, 'prefetch_size': 2, 'cache_usage': False, 'parallelism': 1} reason=CPU bottleneck detected; increasing num_workers
+[iter=4] EVAL score=2866.996 improved=True throughput=2863.647 gpu=31.7 latency=22.879 failed=False
+[iter=5] PLAN config={'batch_size': 64, 'num_workers': 6, 'prefetch_size': 2, 'cache_usage': False, 'parallelism': 1} reason=CPU bottleneck detected; increasing num_workers
+[iter=5] EVAL score=2845.328 improved=False throughput=2841.829 gpu=32.08 latency=22.606 failed=False
+[iter=6] PLAN config={'batch_size': 64, 'num_workers': 5, 'prefetch_size': 3, 'cache_usage': False, 'parallelism': 1} reason=GPU idle detected; increasing prefetch_size
+[iter=6] EVAL score=2987.087 improved=True throughput=2982.895 gpu=33.89 latency=21.403 failed=False
+[iter=7] PLAN config={'batch_size': 64, 'num_workers': 6, 'prefetch_size': 3, 'cache_usage': False, 'parallelism': 1} reason=CPU bottleneck detected; increasing num_workers
+[iter=7] EVAL score=3048.447 improved=True throughput=3044.102 gpu=34.3 latency=21.148 failed=False
+[iter=8] PLAN config={'batch_size': 64, 'num_workers': 7, 'prefetch_size': 3, 'cache_usage': False, 'parallelism': 1} reason=CPU bottleneck detected; increasing num_workers
+[iter=8] EVAL score=3115.401 improved=True throughput=3110.947 gpu=34.59 latency=20.965 failed=False

--- a/docs/drclaw_example_artifacts/metrics.json
+++ b/docs/drclaw_example_artifacts/metrics.json
@@ -1,0 +1,258 @@
+[
+  {
+    "iteration": 1,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 2,
+      "prefetch_size": 2,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "Bootstrap: increase batch_size to probe throughput ceiling",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 2509.446,
+      "gpu_utilization": 28.63,
+      "latency_ms_per_batch": 25.336,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 4.75,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.16,
+        "producer_total": 25.336,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 2511.5362999999998,
+    "is_best": true
+  },
+  {
+    "iteration": 2,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 3,
+      "prefetch_size": 2,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "CPU bottleneck detected; increasing num_workers",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 2610.33,
+      "gpu_utilization": 30.26,
+      "latency_ms_per_batch": 23.971,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 3.167,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.16,
+        "producer_total": 23.971,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 2613.1008,
+    "is_best": true
+  },
+  {
+    "iteration": 3,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 4,
+      "prefetch_size": 2,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "CPU bottleneck detected; increasing num_workers",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 2695.886,
+      "gpu_utilization": 31.14,
+      "latency_ms_per_batch": 23.289,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 2.375,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.16,
+        "producer_total": 23.289,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 2699.0132,
+    "is_best": true
+  },
+  {
+    "iteration": 4,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 5,
+      "prefetch_size": 2,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "CPU bottleneck detected; increasing num_workers",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 2863.647,
+      "gpu_utilization": 31.7,
+      "latency_ms_per_batch": 22.879,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 1.9,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.16,
+        "producer_total": 22.879,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 2866.9962,
+    "is_best": true
+  },
+  {
+    "iteration": 5,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 6,
+      "prefetch_size": 2,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "CPU bottleneck detected; increasing num_workers",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 2841.829,
+      "gpu_utilization": 32.08,
+      "latency_ms_per_batch": 22.606,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 1.583,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.16,
+        "producer_total": 22.606,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 2845.3278,
+    "is_best": false
+  },
+  {
+    "iteration": 6,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 5,
+      "prefetch_size": 3,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "GPU idle detected; increasing prefetch_size",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 2982.895,
+      "gpu_utilization": 33.89,
+      "latency_ms_per_batch": 21.403,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 1.9,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.24,
+        "producer_total": 21.403,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 2987.0869,
+    "is_best": true
+  },
+  {
+    "iteration": 7,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 6,
+      "prefetch_size": 3,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "CPU bottleneck detected; increasing num_workers",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 3044.102,
+      "gpu_utilization": 34.3,
+      "latency_ms_per_batch": 21.148,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 1.583,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.24,
+        "producer_total": 21.148,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 3048.4473999999996,
+    "is_best": true
+  },
+  {
+    "iteration": 8,
+    "config": {
+      "batch_size": 64,
+      "num_workers": 7,
+      "prefetch_size": 3,
+      "cache_usage": false,
+      "parallelism": 1
+    },
+    "decision_reason": "CPU bottleneck detected; increasing num_workers",
+    "reverted": false,
+    "metrics": {
+      "throughput_samples_per_sec": 3110.947,
+      "gpu_utilization": 34.59,
+      "latency_ms_per_batch": 20.965,
+      "cpu_bottleneck": true,
+      "gpu_idle": true,
+      "failed": false,
+      "failure_reason": null,
+      "raw_stage_times_ms": {
+        "data_loading": 8.0,
+        "decode": 1.357,
+        "transform": 12.0,
+        "batch": 4.64,
+        "prefetch_effective_divisor": 1.24,
+        "producer_total": 20.965,
+        "gpu_compute": 7.253
+      }
+    },
+    "score": 3115.4015,
+    "is_best": true
+  }
+]

--- a/docs/drclaw_example_artifacts/summary.md
+++ b/docs/drclaw_example_artifacts/summary.md
@@ -1,0 +1,5 @@
+# Experiment Summary: drclaw_default
+
+- Iterations executed: 8
+- Best score: 3115.401
+- Best config: `{'batch_size': 64, 'num_workers': 7, 'prefetch_size': 3, 'cache_usage': False, 'parallelism': 1}`

--- a/docs/drclaw_migration.md
+++ b/docs/drclaw_migration.md
@@ -1,0 +1,30 @@
+# UAgent-DrClaw Migration Analysis
+
+## Scope
+This note summarizes how the current repository is wired to OpenHands and where to decouple for a standalone autonomous research loop.
+
+## OpenHands-specific components identified
+
+1. **Session-centric orchestration**
+   - `WebSession` in `OpenHands/openhands/server/session/session.py` owns lifecycle for web socket events, runtime interaction, and research hooks.
+   - It eagerly constructs `AgentSession` and conditionally integrates research middleware, coupling UI/session concerns with research execution.
+
+2. **Coordinator wrapper around existing research stack**
+   - `MultiAgentCoordinator` in `OpenHands/openhands/server/session/multi_agent_coordinator.py` manages sub-agent lifecycle and proxies to `TreeSearchOrchestrator` from `uagent_research`.
+   - Current flow is tightly tied to OpenHands event buses (`EventBus`, `ControlBus`, `MessageBus`) and streaming observations.
+
+3. **Execution flow currently in server path**
+   - Research execution is started from session-level message handling, then tracked as background tasks by the coordinator, then reported back to session streams.
+   - This makes autonomous experiment optimization hard to run headless/reproducibly without server bootstrapping.
+
+## Migration direction for DrClaw
+
+- Extract a **headless experiment loop** independent of web session and runtime abstractions.
+- Keep extensibility by defining module boundaries (`planner`, `executor`, `evaluator`, `memory`, `experiments`).
+- Preserve iterative orchestration semantics but simplify to deterministic experiment runs and file-based outputs for reproducibility.
+- Decouple policy logic from execution so future LLM/RL planners can be swapped in without touching simulator or memory layers.
+
+## Assumptions
+
+- DrClaw is an experimental prototype and can run as a standalone Python entrypoint (`experiment_runner.py`).
+- Existing OpenHands runtime/event infra remains intact and unchanged; DrClaw is additive and does not break legacy behavior.

--- a/docs/experiment_design.md
+++ b/docs/experiment_design.md
@@ -1,0 +1,37 @@
+# Experiment Design for UAgent-DrClaw
+
+## Objective
+Optimize ML input pipeline behavior by tuning:
+- `batch_size`
+- `num_workers`
+- `prefetch_size`
+- `cache_usage`
+- `parallelism`
+
+Metrics:
+- throughput (samples/sec)
+- approximate GPU utilization
+- latency per batch (ms)
+
+## Simulated pipeline stages
+1. Data loading
+2. Decode
+3. Transform
+4. Batch
+5. Prefetch
+
+The simulator models CPU preprocessing pressure and GPU idle conditions by comparing producer-side latency with GPU compute latency.
+
+## Decision policy v1
+- Increase `batch_size` as primary lever.
+- If CPU bottleneck, increase `num_workers`.
+- If GPU idle, increase `prefetch_size`.
+- If a run fails (e.g., OOM), revert to best known configuration.
+
+## Convergence
+Stop when there is no improvement for `no_improvement_patience` consecutive iterations, or when `max_iterations` is reached.
+
+## Reproducibility
+- Config-driven run.
+- Deterministic random seed in simulator.
+- All iteration artifacts logged per run directory.

--- a/uagent_drclaw/__init__.py
+++ b/uagent_drclaw/__init__.py
@@ -1,0 +1,5 @@
+"""UAgent-DrClaw autonomous ML pipeline optimization prototype."""
+
+__all__ = [
+    "agent_loop",
+]

--- a/uagent_drclaw/evaluator/__init__.py
+++ b/uagent_drclaw/evaluator/__init__.py
@@ -1,0 +1,3 @@
+from .metrics_evaluator import MetricsEvaluator
+
+__all__ = ["MetricsEvaluator"]

--- a/uagent_drclaw/evaluator/metrics_evaluator.py
+++ b/uagent_drclaw/evaluator/metrics_evaluator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from uagent_drclaw.types import ExperimentMetrics
+
+
+class MetricsEvaluator:
+    """Weighted scoring for pipeline optimization objective."""
+
+    def __init__(self, throughput_weight: float = 1.0, gpu_weight: float = 0.25, latency_weight: float = 0.2):
+        self.throughput_weight = throughput_weight
+        self.gpu_weight = gpu_weight
+        self.latency_weight = latency_weight
+
+    def score(self, metrics: ExperimentMetrics) -> float:
+        if metrics.failed:
+            return float("-inf")
+
+        return (
+            self.throughput_weight * metrics.throughput_samples_per_sec
+            + self.gpu_weight * metrics.gpu_utilization
+            - self.latency_weight * metrics.latency_ms_per_batch
+        )
+
+    def improved(self, current: float, best: float) -> bool:
+        return current > best

--- a/uagent_drclaw/executor/__init__.py
+++ b/uagent_drclaw/executor/__init__.py
@@ -1,0 +1,3 @@
+from .experiment_executor import ExperimentExecutor
+
+__all__ = ["ExperimentExecutor"]

--- a/uagent_drclaw/executor/experiment_executor.py
+++ b/uagent_drclaw/executor/experiment_executor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import traceback
+
+from uagent_drclaw.executor.pipeline_simulator import PipelineSimulator
+from uagent_drclaw.types import ExperimentMetrics, PipelineConfig
+
+
+class ExperimentExecutor:
+    def __init__(self, simulator: PipelineSimulator | None = None):
+        self.simulator = simulator or PipelineSimulator()
+
+    def execute(self, config: PipelineConfig) -> ExperimentMetrics:
+        try:
+            return self.simulator.run(config)
+        except Exception as exc:  # Failure recovery path
+            return ExperimentMetrics(
+                throughput_samples_per_sec=0,
+                gpu_utilization=0,
+                latency_ms_per_batch=0,
+                cpu_bottleneck=True,
+                gpu_idle=True,
+                failed=True,
+                failure_reason=f"ExecutorError: {exc}\n{traceback.format_exc()}"[:1000],
+            )

--- a/uagent_drclaw/executor/pipeline_simulator.py
+++ b/uagent_drclaw/executor/pipeline_simulator.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import random
+
+from uagent_drclaw.types import ExperimentMetrics, PipelineConfig
+
+
+class PipelineSimulator:
+    """Deterministic-ish simulator for ML input pipeline behavior."""
+
+    def __init__(self, seed: int = 7):
+        self.seed = seed
+
+    def run(self, config: PipelineConfig) -> ExperimentMetrics:
+        if config.batch_size > 1024:
+            return ExperimentMetrics(
+                throughput_samples_per_sec=0,
+                gpu_utilization=0,
+                latency_ms_per_batch=0,
+                cpu_bottleneck=True,
+                gpu_idle=True,
+                failed=True,
+                failure_reason="OutOfMemory: batch_size exceeded simulated GPU memory budget",
+            )
+
+        # Stage model (ms)
+        load_ms = max(1.0, 8.0 - (1.5 if config.cache_usage else 0.0))
+        decode_ms = max(1.0, 9.5 / max(config.num_workers, 1))
+        transform_ms = max(1.0, 12.0 / max(config.parallelism, 1))
+        batch_ms = max(1.0, 4.0 + config.batch_size / 100.0)
+        prefetch_gain = 1.0 + (config.prefetch_size * 0.08)
+
+        cpu_stage_ms = load_ms + decode_ms + transform_ms
+        producer_ms = (cpu_stage_ms + batch_ms) / prefetch_gain
+
+        # Simulated GPU consumption time per batch
+        gpu_compute_ms = max(2.5, 6.5 + (config.batch_size / 85.0))
+        latency_ms = max(producer_ms, gpu_compute_ms)
+
+        throughput = config.batch_size / (latency_ms / 1000.0)
+        gpu_utilization = min(99.0, (gpu_compute_ms / latency_ms) * 100.0)
+        signature = (
+            config.batch_size * 31
+            + config.num_workers * 17
+            + config.prefetch_size * 13
+            + int(config.cache_usage) * 7
+            + config.parallelism * 19
+        )
+        local_rng = random.Random(self.seed + signature)
+        jitter = local_rng.uniform(-0.03, 0.03)
+        throughput *= (1 + jitter)
+
+        cpu_bottleneck = producer_ms > gpu_compute_ms * 1.10
+        gpu_idle = gpu_utilization < 68.0
+
+        return ExperimentMetrics(
+            throughput_samples_per_sec=round(throughput, 3),
+            gpu_utilization=round(gpu_utilization, 2),
+            latency_ms_per_batch=round(latency_ms, 3),
+            cpu_bottleneck=cpu_bottleneck,
+            gpu_idle=gpu_idle,
+            raw_stage_times_ms={
+                "data_loading": round(load_ms, 3),
+                "decode": round(decode_ms, 3),
+                "transform": round(transform_ms, 3),
+                "batch": round(batch_ms, 3),
+                "prefetch_effective_divisor": round(prefetch_gain, 3),
+                "producer_total": round(producer_ms, 3),
+                "gpu_compute": round(gpu_compute_ms, 3),
+            },
+        )

--- a/uagent_drclaw/experiment_runner.py
+++ b/uagent_drclaw/experiment_runner.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from uagent_drclaw.evaluator import MetricsEvaluator
+from uagent_drclaw.executor import ExperimentExecutor
+from uagent_drclaw.executor.pipeline_simulator import PipelineSimulator
+from uagent_drclaw.memory import ExperimentMemory
+from uagent_drclaw.planner import HeuristicPlanner
+from uagent_drclaw.types import PipelineConfig
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        return yaml.safe_load(text)
+    except Exception:
+        # Tiny fallback parser for this known config shape
+        data: dict[str, Any] = {}
+        section: str | None = None
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.endswith(":"):
+                section = line[:-1]
+                data[section] = {}
+                continue
+            if ":" in line and section is not None:
+                k, v = [p.strip() for p in line.split(":", 1)]
+                if v.lower() in {"true", "false"}:
+                    parsed: Any = v.lower() == "true"
+                else:
+                    try:
+                        parsed = int(v)
+                    except ValueError:
+                        try:
+                            parsed = float(v)
+                        except ValueError:
+                            parsed = v
+                data[section][k] = parsed
+        return data
+
+
+def _now_stamp() -> str:
+    return datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+
+def run_agent_loop(config_path: Path, output_root: Path) -> Path:
+    cfg = _load_yaml(config_path)
+    exp_cfg = cfg["experiment"]
+    search = cfg["search_space"]
+
+    initial = PipelineConfig.from_dict(cfg["initial_config"])
+    planner = HeuristicPlanner(
+        max_batch_size=int(search["max_batch_size"]),
+        max_workers=int(search["max_workers"]),
+        max_prefetch=int(search["max_prefetch_size"]),
+        max_parallelism=int(search["max_parallelism"]),
+    )
+    executor = ExperimentExecutor(
+        simulator=PipelineSimulator(seed=int(exp_cfg.get("random_seed", 7)))
+    )
+    evaluator = MetricsEvaluator()
+    memory = ExperimentMemory()
+
+    run_dir = output_root / f"{exp_cfg['name']}_{_now_stamp()}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    logs: list[str] = [
+        "[assumption] Pipeline metrics are simulator-derived approximations for research prototyping",
+        "[assumption] Convergence is no-improvement patience based, not statistical significance",
+    ]
+    metrics_log: list[dict[str, Any]] = []
+
+    max_iterations = int(exp_cfg["max_iterations"])
+    patience = int(exp_cfg["no_improvement_patience"])
+    no_improvement = 0
+
+    current = initial
+    last_metrics = None
+
+    for i in range(1, max_iterations + 1):
+        decision = planner.propose(current, last_metrics, memory)
+        candidate = decision.candidate
+
+        logs.append(f"[iter={i}] PLAN config={candidate.to_dict()} reason={decision.reason}")
+
+        result = executor.execute(candidate)
+        score = evaluator.score(result)
+
+        memory.record(candidate, result, score)
+
+        improved = memory.best_config == candidate and not result.failed
+        if improved:
+            no_improvement = 0
+        else:
+            no_improvement += 1
+
+        logs.append(
+            f"[iter={i}] EVAL score={score:.3f} improved={improved} "
+            f"throughput={result.throughput_samples_per_sec} "
+            f"gpu={result.gpu_utilization} latency={result.latency_ms_per_batch} "
+            f"failed={result.failed}"
+        )
+
+        metrics_log.append(
+            {
+                "iteration": i,
+                "config": candidate.to_dict(),
+                "decision_reason": decision.reason,
+                "reverted": decision.reverted,
+                "metrics": asdict(result),
+                "score": score,
+                "is_best": improved,
+            }
+        )
+
+        current = memory.best_config or current
+        last_metrics = result
+
+        if no_improvement >= patience:
+            logs.append(f"[iter={i}] STOP no improvement for {patience} iterations")
+            break
+
+    best = memory.best_config
+    summary = {
+        "experiment_name": exp_cfg["name"],
+        "iterations_executed": len(metrics_log),
+        "best_config": best.to_dict() if best else None,
+        "best_score": memory.best_score,
+    }
+
+    (run_dir / "metrics.json").write_text(json.dumps(metrics_log, indent=2), encoding="utf-8")
+    (run_dir / "logs.txt").write_text("\n".join(logs) + "\n", encoding="utf-8")
+
+    summary_lines = [
+        f"# Experiment Summary: {exp_cfg['name']}",
+        "",
+        f"- Iterations executed: {summary['iterations_executed']}",
+        f"- Best score: {summary['best_score']:.3f}",
+        f"- Best config: `{summary['best_config']}`",
+    ]
+    (run_dir / "summary.md").write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+    return run_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run UAgent-DrClaw autonomous optimization loop")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("uagent_drclaw/experiments/config.yaml"),
+        help="Path to experiment YAML config",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("uagent_drclaw/results"),
+        help="Folder for experiment outputs",
+    )
+    args = parser.parse_args()
+
+    run_dir = run_agent_loop(args.config, args.output_root)
+    print(f"DrClaw run complete. Results written to: {run_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/uagent_drclaw/experiments/config.yaml
+++ b/uagent_drclaw/experiments/config.yaml
@@ -1,0 +1,18 @@
+experiment:
+  name: drclaw_default
+  max_iterations: 8
+  no_improvement_patience: 3
+  random_seed: 7
+
+search_space:
+  max_batch_size: 1024
+  max_workers: 12
+  max_prefetch_size: 16
+  max_parallelism: 8
+
+initial_config:
+  batch_size: 32
+  num_workers: 2
+  prefetch_size: 2
+  cache_usage: false
+  parallelism: 1

--- a/uagent_drclaw/memory/__init__.py
+++ b/uagent_drclaw/memory/__init__.py
@@ -1,0 +1,3 @@
+from .experiment_memory import ExperimentMemory
+
+__all__ = ["ExperimentMemory"]

--- a/uagent_drclaw/memory/experiment_memory.py
+++ b/uagent_drclaw/memory/experiment_memory.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from uagent_drclaw.types import ExperimentMetrics, PipelineConfig
+
+
+@dataclass
+class MemoryEntry:
+    config: PipelineConfig
+    metrics: ExperimentMetrics
+
+
+@dataclass
+class ExperimentMemory:
+    history: list[MemoryEntry] = field(default_factory=list)
+    best_config: PipelineConfig | None = None
+    best_score: float = float("-inf")
+    _bad_configs: set[tuple] = field(default_factory=set)
+    _seen_configs: set[tuple] = field(default_factory=set)
+
+    def record(self, config: PipelineConfig, metrics: ExperimentMetrics, score: float) -> None:
+        self._seen_configs.add(self._signature(config))
+        self.history.append(MemoryEntry(config=config, metrics=metrics))
+        if metrics.failed:
+            self._bad_configs.add(self._signature(config))
+            return
+
+        if score > self.best_score:
+            self.best_score = score
+            self.best_config = config
+
+    def is_known_bad(self, config: PipelineConfig) -> bool:
+        return self._signature(config) in self._bad_configs
+
+    def has_seen(self, config: PipelineConfig) -> bool:
+        return self._signature(config) in self._seen_configs
+
+    @staticmethod
+    def _signature(config: PipelineConfig) -> tuple:
+        return (
+            config.batch_size,
+            config.num_workers,
+            config.prefetch_size,
+            config.cache_usage,
+            config.parallelism,
+        )

--- a/uagent_drclaw/planner/__init__.py
+++ b/uagent_drclaw/planner/__init__.py
@@ -1,0 +1,3 @@
+from .heuristic_planner import HeuristicPlanner
+
+__all__ = ["HeuristicPlanner"]

--- a/uagent_drclaw/planner/heuristic_planner.py
+++ b/uagent_drclaw/planner/heuristic_planner.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from uagent_drclaw.memory.experiment_memory import ExperimentMemory
+from uagent_drclaw.types import ExperimentMetrics, PipelineConfig, PlanDecision
+
+
+class HeuristicPlanner:
+    """Rule-based planning policy designed for later replacement by learned policies."""
+
+    def __init__(
+        self,
+        max_batch_size: int,
+        max_workers: int,
+        max_prefetch: int,
+        max_parallelism: int,
+    ):
+        self.max_batch_size = max_batch_size
+        self.max_workers = max_workers
+        self.max_prefetch = max_prefetch
+        self.max_parallelism = max_parallelism
+
+    def propose(
+        self,
+        current: PipelineConfig,
+        last_metrics: ExperimentMetrics | None,
+        memory: ExperimentMemory,
+    ) -> PlanDecision:
+        candidate = current
+        reason = "No-op fallback to preserve stability"
+
+        if last_metrics and last_metrics.failed:
+            if "OutOfMemory" in (last_metrics.failure_reason or "") and current.batch_size > 1:
+                reduced = replace(current, batch_size=max(1, current.batch_size // 2))
+                if not memory.is_known_bad(reduced):
+                    return PlanDecision(
+                        candidate=reduced,
+                        reason="OOM detected; reducing batch_size for recovery",
+                        reverted=True,
+                    )
+            candidate = memory.best_config or current
+            reason = f"Last run failed ({last_metrics.failure_reason}); reverting to known-good config"
+            return PlanDecision(candidate=candidate, reason=reason, reverted=True)
+
+        proposals: list[tuple[PipelineConfig, str]] = []
+
+        if last_metrics is None:
+            proposals.append(
+                (
+                    replace(current, batch_size=min(current.batch_size * 2, self.max_batch_size)),
+                    "Bootstrap: increase batch_size to probe throughput ceiling",
+                )
+            )
+        else:
+            if last_metrics.cpu_bottleneck and current.num_workers < self.max_workers:
+                proposals.append(
+                    (
+                        replace(current, num_workers=min(current.num_workers + 1, self.max_workers)),
+                        "CPU bottleneck detected; increasing num_workers",
+                    )
+                )
+            if last_metrics.gpu_idle and current.prefetch_size < self.max_prefetch:
+                proposals.append(
+                    (
+                        replace(current, prefetch_size=min(current.prefetch_size + 1, self.max_prefetch)),
+                        "GPU idle detected; increasing prefetch_size",
+                    )
+                )
+
+        if current.batch_size < self.max_batch_size:
+            proposals.append(
+                (
+                    replace(current, batch_size=min(current.batch_size * 2, self.max_batch_size)),
+                    "Trying larger batch_size for better device occupancy",
+                )
+            )
+        if current.parallelism < self.max_parallelism:
+            proposals.append(
+                (
+                    replace(current, parallelism=min(current.parallelism + 1, self.max_parallelism)),
+                    "Exploring higher transform parallelism",
+                )
+            )
+        proposals.append((replace(current, cache_usage=not current.cache_usage), "Exploring cache toggle"))
+
+        for proposal, proposal_reason in proposals:
+            if not memory.is_known_bad(proposal) and not memory.has_seen(proposal):
+                candidate = proposal
+                reason = proposal_reason
+                break
+
+        if memory.is_known_bad(candidate):
+            fallback = memory.best_config or current
+            return PlanDecision(
+                candidate=fallback,
+                reason="Proposed configuration was previously bad; reverting to best known config",
+                reverted=True,
+            )
+
+        return PlanDecision(candidate=candidate, reason=reason)

--- a/uagent_drclaw/types.py
+++ b/uagent_drclaw/types.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    batch_size: int = 32
+    num_workers: int = 2
+    prefetch_size: int = 2
+    cache_usage: bool = False
+    parallelism: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "batch_size": self.batch_size,
+            "num_workers": self.num_workers,
+            "prefetch_size": self.prefetch_size,
+            "cache_usage": self.cache_usage,
+            "parallelism": self.parallelism,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PipelineConfig":
+        return cls(
+            batch_size=int(data.get("batch_size", 32)),
+            num_workers=int(data.get("num_workers", 2)),
+            prefetch_size=int(data.get("prefetch_size", 2)),
+            cache_usage=bool(data.get("cache_usage", False)),
+            parallelism=int(data.get("parallelism", 1)),
+        )
+
+
+@dataclass
+class ExperimentMetrics:
+    throughput_samples_per_sec: float
+    gpu_utilization: float
+    latency_ms_per_batch: float
+    cpu_bottleneck: bool
+    gpu_idle: bool
+    failed: bool = False
+    failure_reason: str | None = None
+    raw_stage_times_ms: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class PlanDecision:
+    candidate: PipelineConfig
+    reason: str
+    reverted: bool = False


### PR DESCRIPTION
### Motivation
- Decouple a headless, reproducible research loop from OpenHands session/server wiring to enable independent experimentation on ML input pipeline knobs. 
- Provide a minimal but complete plan→act→run→evaluate→refine prototype that is modular and extensible for future LLM/RL policies. 
- Ensure runs are deterministic, logged, and recoverable so experiments can be reproduced and iterated automatically.

### Description
- Add a new `uagent_drclaw` package implementing the modular architecture: `planner/`, `executor/`, `evaluator/`, `memory/`, and `experiments/`, and a top-level entry `experiment_runner.py` to run the autonomous loop. 
- Implement a deterministic `PipelineSimulator` in `executor/` that models stages (`data_loading`, `decode`, `transform`, `batch`, `prefetch`), simulates CPU/GPU bottlenecks and OOM failure, and uses a seeded signature-based jitter for reproducibility. 
- Implement a `HeuristicPlanner` that proposes parameter changes (`batch_size`, `num_workers`, `prefetch_size`, `parallelism`, `cache_usage`) with safeguards: avoids known-bad configs, records seen configs, and includes OOM recovery by reducing `batch_size`. 
- Implement `ExperimentMemory` to store history, track `best_config`/score, mark bad configs, and prevent repeating seen bad candidates; add `MetricsEvaluator` to compute scalar scores; add YAML-driven experiment config and documented reproducible outputs (`metrics.json`, `logs.txt`, `summary.md`).

### Testing
- Ran `python -m uagent_drclaw.experiment_runner` and confirmed the run completed and wrote artifacts to `uagent_drclaw/results/` (success). 
- Re-ran `python -m uagent_drclaw.experiment_runner` to validate reproducibility and observed consistent optimization progress (success). 
- Ran failure-recovery scenario with `python -m uagent_drclaw.experiment_runner --config /tmp/drclaw_oom.yaml` to exercise OOM handling and automatic recovery, and verified the planner reduced `batch_size` and the run recovered (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddae2a12308329b2174baf3a09db9b)